### PR TITLE
Initial CI support to compile the demo

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,30 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the develop branch
+  push:
+  #pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  #workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  compile-demo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Compile simple sel4cp application
+        uses: addnab/docker-run-action@v3
+        with:
+          image: podhrmic/rust-sel4-sel4cp-demo:latest
+          options: -v ${{ github.workspace }}:/work
+          run: |
+            make compile
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,4 +27,29 @@ jobs:
           options: -v ${{ github.workspace }}:/work
           run: |
             make compile
+      - uses: actions/upload-artifact@v3
+        if: success()
+        with:
+          name: loader
+          path: build/loader.img
+          retention-days: 1
 
+  run-demo:
+    runs-on: ubuntu-latest
+    needs: compile-demo
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: actions/download-artifact@v3
+        with:
+          name: loader
+      - name: Compile simple sel4cp application
+        uses: addnab/docker-run-action@v3
+        with:
+          image: podhrmic/rust-sel4-sel4cp-demo:latest
+          options: -v ${{ github.workspace }}:/work
+          run: |
+            python3 test.py
+            cat log.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,16 +45,14 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: loader
-        run: |
-          pwd
-          ls -l
-          ls -l build
       - name: Run simple sel4cp application
         uses: addnab/docker-run-action@v3
         with:
           image: podhrmic/rust-sel4-sel4cp-demo:latest
           options: -v ${{ github.workspace }}:/work
           run: |
+            pwd
+            ls -l
             python3 test.py
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,13 +45,16 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: loader
+        run: |
+          pwd
+          ls -l
+          ls -l build
       - name: Run simple sel4cp application
         uses: addnab/docker-run-action@v3
         with:
           image: podhrmic/rust-sel4-sel4cp-demo:latest
           options: -v ${{ github.workspace }}:/work
           run: |
-            ls build
             python3 test.py
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,11 +45,12 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: loader
-      - name: Compile simple sel4cp application
+      - name: Run simple sel4cp application
         uses: addnab/docker-run-action@v3
         with:
           image: podhrmic/rust-sel4-sel4cp-demo:latest
           options: -v ${{ github.workspace }}:/work
           run: |
+            ls build
             python3 test.py
             cat log.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,8 +51,8 @@ jobs:
           image: podhrmic/rust-sel4-sel4cp-demo:latest
           options: -v ${{ github.workspace }}:/work
           run: |
-            pwd
-            ls -l
+            mkdir -p build
+            mv loader.img build/loader.img
             python3 test.py
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,4 +53,8 @@ jobs:
           run: |
             ls build
             python3 test.py
-            cat log.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: log
+          path: log.txt
+          retention-days: 1

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ compile: $(loader)
 	echo "Done!"
 
 .PHONY: run
-run: compile
+run:
 	qemu-system-aarch64 \
 		-machine virt \
 		-cpu cortex-a53 -m size=1G \

--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,11 @@ $(loader): $(system_description) $(built_crates)
 		-r $(build_dir)/report.txt \
 		-o $@
 
+compile: $(loader)
+	echo "Done!"
+
 .PHONY: run
-run: $(loader)
+run: compile
 	qemu-system-aarch64 \
 		-machine virt \
 		-cpu cortex-a53 -m size=1G \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,12 +72,4 @@ RUN cd sel4cp && \
 
 ENV SEL4CP_SDK=/deps/sel4cp/release/sel4cp-sdk-$SEL4CP_SDK_VERSION
 
-ARG UID
-ARG GID
-
-RUN groupadd -f -g $GID x && useradd -u $UID -g $GID -G sudo -m -p x x
-RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers # for convenience
-
-USER x
-
 WORKDIR /work

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,35 +1,16 @@
 work_root := ..
 
-label := rust-sel4-sel4cp-demo
-image_repository := $(label)
-image_tag := $(image_repository)
-container_name := $(label)
+image_tag := podhrmic/rust-sel4-sel4cp-demo
 dockerfile := Dockerfile
-
-uid := $(shell id -u)
-gid := $(shell id -g)
 
 .PHONY: none
 none:
 
 .PHONY: build
 build:
-	docker build \
-		--build-arg UID=$(uid) --build-arg GID=$(gid) \
-		--label $(label) -t $(image_tag) -f $(dockerfile) .
+	sudo docker build \
+		-t $(image_tag) -f $(dockerfile) .
 
 .PHONY: run
 run: build
-	docker run -d --name $(container_name) --label $(label) \
-		--mount type=bind,src=$(abspath $(work_root)),dst=/work \
-		$(image_tag) sleep inf
-
-.PHONY: exec
-exec:
-	docker exec -it $(container_name) bash
-
-.PHONY: rm-container
-rm-container:
-	for id in $$(docker ps -aq -f "name=^$(container_name)$$"); do \
-		docker rm -f $$id; \
-	done
+	sudo docker run -it -w /work -v $(abspath $(work_root)):/work  $(image_tag)

--- a/test.py
+++ b/test.py
@@ -17,3 +17,5 @@ child.sendcontrol('A')
 child.send('x')
 # Termination confirmation
 child.expect('QEMU: Terminated',timeout=1)
+
+print("Test Succeeded!")

--- a/test.py
+++ b/test.py
@@ -1,0 +1,19 @@
+# Simple test script
+import pexpect
+
+
+# Start QEMU
+child = pexpect.spawn('make run',encoding='utf-8')
+fout = open('log.txt','w')
+child.logfile = fout
+# Wait for the prompt
+child.expect('banscii>',timeout=1)
+# Try hello world
+child.sendline('Hello World\r')
+# Wait for the prompt (ignore the output)
+child.expect('banscii>',timeout=1)
+# Escape sequence
+child.sendcontrol('A')
+child.send('x')
+# Termination confirmation
+child.expect('QEMU: Terminated',timeout=1)


### PR DESCRIPTION
* This PR enables github actions and compiles the demo `loader.img`
* Small changes in how docker image is built (no UID), so it is easier to use in the CI runner
* The docker image is ideally built and pushed automatically (on change) as well, ideally to seL4 dockerhub (and not my private one)
* Proper testing would need to be added, perhaps by utilizing Qemu Avocado framework