### PR TITLE
Update Microkit rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,7 +726,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 [[package]]
 name = "sel4"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "cfg-if",
  "sel4-config",
@@ -736,12 +736,12 @@ dependencies = [
 [[package]]
 name = "sel4-bitfield-ops"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 
 [[package]]
 name = "sel4-bitfield-parser"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "pest",
  "pest_derive",
@@ -751,12 +751,12 @@ dependencies = [
 [[package]]
 name = "sel4-build-env"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 
 [[package]]
 name = "sel4-config"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "sel4-config-macros",
 ]
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-data"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "lazy_static",
  "sel4-build-env",
@@ -775,7 +775,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-generic-macro-impls"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "fallible-iterator",
  "proc-macro2",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-generic-types"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "serde",
 ]
@@ -795,7 +795,7 @@ dependencies = [
 [[package]]
 name = "sel4-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "sel4-config-data",
  "sel4-config-generic-macro-impls",
@@ -804,7 +804,7 @@ dependencies = [
 [[package]]
 name = "sel4-dlmalloc"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "dlmalloc",
  "sel4-sync",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "sel4-externally-shared"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "volatile",
  "zerocopy",
@@ -822,17 +822,17 @@ dependencies = [
 [[package]]
 name = "sel4-immediate-sync-once-cell"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 
 [[package]]
 name = "sel4-immutable-cell"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 
 [[package]]
 name = "sel4-initialize-tls-on-stack"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "cfg-if",
  "sel4",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "sel4-microkit"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "cfg-if",
  "sel4",
@@ -857,7 +857,7 @@ dependencies = [
 [[package]]
 name = "sel4-microkit-macros"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "sel4-microkit-message"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "sel4-microkit",
  "sel4-microkit-message-types",
@@ -877,7 +877,7 @@ dependencies = [
 [[package]]
 name = "sel4-microkit-message-types"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "num_enum",
  "postcard",
@@ -888,7 +888,7 @@ dependencies = [
 [[package]]
 name = "sel4-panicking"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "cfg-if",
  "sel4-immediate-sync-once-cell",
@@ -899,12 +899,12 @@ dependencies = [
 [[package]]
 name = "sel4-panicking-env"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 
 [[package]]
 name = "sel4-runtime-common"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "cfg-if",
  "sel4-dlmalloc",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "sel4-rustfmt-helper"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "which",
 ]
@@ -924,7 +924,7 @@ dependencies = [
 [[package]]
 name = "sel4-sync"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "sel4",
  "sel4-immediate-sync-once-cell",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "sel4-sys"
 version = "0.1.0"
-source = "git+https://github.com/seL4/rust-sel4#c55256d1f66ad00681da511fdd42789fe6298165"
+source = "git+https://github.com/seL4/rust-sel4#4a2e12565e1ee1fce6fc4ef012f412ab29243a5a"
 dependencies = [
  "bindgen",
  "glob",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ ENV MICROKIT_SDK_VERSION=1.2.6
 # branch: rust
 RUN git clone \
         https://github.com/coliasgroup/microkit.git \
-        --branch keep/acab5b66cb8d66754deb18736fc82a4b \
+        --branch keep/004e340a38d1ed7bf9d1a0223aff8475 \
         --config advice.detachedHead=false
 
 # branch: rust-microkit


### PR DESCRIPTION
This new rev drops the [`setvar` patch](https://github.com/coliasgroup/microkit/commit/acab5b66cb8d66754deb18736fc82a4b) that will not be upstreamed.